### PR TITLE
Use payload as string instead of map

### DIFF
--- a/lib/notifiex.ex
+++ b/lib/notifiex.ex
@@ -9,7 +9,7 @@ defmodule Notifiex do
 
   @type id :: atom
   @type service :: atom
-  @type payload :: map
+  @type payload :: binary
   @type options :: map
   @type result :: {:ok, any} | {:error, {atom, any}}
   @type send_type :: :sync | :async

--- a/lib/notifiex/notification.ex
+++ b/lib/notifiex/notification.ex
@@ -18,7 +18,7 @@ defmodule Notifiex.Notification do
 
     case notification do
       {service, payload, options}
-      when is_atom(service) and is_map(payload) and is_map(options) ->
+      when is_atom(service) and is_binary(payload) and is_map(options) ->
         sender.(service, payload, options)
 
       [_] ->

--- a/lib/notifiex/services/discord.ex
+++ b/lib/notifiex/services/discord.ex
@@ -14,19 +14,17 @@ defmodule Notifiex.Service.Discord do
   `options` should include the following:
   * `webhook`: Webhook URI. (required)
   """
-  @spec call(map, map) :: {:ok, binary} | {:error, {atom, any}}
-  def call(payload, options) when is_map(payload) and is_map(options) do
+  @spec call(binary, map) :: {:ok, binary} | {:error, {atom, any}}
+  def call(payload, options) when is_binary(payload) and is_map(options) do
     webhook = Map.get(options, :webhook)
 
     send_discord(payload, webhook)
   end
 
-  @spec send_discord(map, binary) :: {:ok, binary} | {:error, {atom, any}}
+  @spec send_discord(binary, binary) :: {:ok, binary} | {:error, {atom, any}}
   defp send_discord(_payload, nil), do: {:error, {:missing_options, nil}}
 
   defp send_discord(payload, url) do
-    json_payload = Poison.encode!(payload)
-
     header = [
       {"Accept", "application/json"},
       {"Content-Type", "application/json; charset=utf-8"}
@@ -34,7 +32,7 @@ defmodule Notifiex.Service.Discord do
 
     HTTPoison.start()
 
-    case HTTPoison.post(url, json_payload, header) do
+    case HTTPoison.post(url, payload, header) do
       {:ok, %HTTPoison.Response{body: response, status_code: 204}} ->
         {:ok, response}
 

--- a/lib/notifiex/services/mock.ex
+++ b/lib/notifiex/services/mock.ex
@@ -9,6 +9,6 @@ defmodule Notifiex.Service.Mock do
   Mock service returns `{:ok, true}` if payload is `{hello: "world"}`, else returns an error response: `{:error, :mock_error, false}`.
   """
   @spec call(map, map) :: {:ok, binary} | {:error, {atom, any}}
-  def call(%{hello: "world"}, _), do: {:ok, true}
-  def call(_, _), do: {:error, {:mock_error, false}}
+  def call("", _), do: {:error, {:mock_error, false}}
+  def call(payload, _), do: {:ok, true}
 end

--- a/lib/notifiex/services/slack.ex
+++ b/lib/notifiex/services/slack.ex
@@ -15,7 +15,7 @@ defmodule Notifiex.Service.Slack do
   `options` should include the following:
   * `token`: Authentication token. (required)
   """
-  @spec call(map, map) :: {:ok, binary} | {:error, {atom, any}}
+  @spec call(binary, map) :: {:ok, binary} | {:error, {atom, any}}
   def call(payload, options) when is_map(payload) and is_map(options) do
     url = "https://slack.com/api/chat.postMessage"
     token = Map.get(options, :token)
@@ -37,12 +37,10 @@ defmodule Notifiex.Service.Slack do
     end
   end
 
-  @spec send_message(map, binary, binary) :: {:ok, binary} | {:error, {atom, any}}
+  @spec send_message(binary, binary, binary) :: {:ok, binary} | {:error, {atom, any}}
   defp send_message(_payload, nil, nil), do: {:error, {:missing_options, nil}}
 
   defp send_message(payload, url, token) do
-    json_payload = Poison.encode!(payload)
-
     header = [
       {"Accept", "application/json"},
       {"Content-Type", "application/json; charset=utf-8"},
@@ -51,7 +49,7 @@ defmodule Notifiex.Service.Slack do
 
     HTTPoison.start()
 
-    case HTTPoison.post(url, json_payload, header) do
+    case HTTPoison.post(url, payload, header) do
       {:ok, %HTTPoison.Response{body: response, status_code: 200}} ->
         {:ok, response}
 

--- a/mix.exs
+++ b/mix.exs
@@ -28,8 +28,7 @@ defmodule Notifiex.MixProject do
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev], runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
-      {:httpoison, "~> 1.8"},
-      {:poison, "~> 5.0"}
+      {:httpoison, "~> 1.8"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -18,7 +18,7 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "poison": {:hex, :poison, "5.0.0", "d2b54589ab4157bbb82ec2050757779bfed724463a544b6e20d79855a9e43b24", [:mix], [{:decimal, "~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "11dc6117c501b80c62a7594f941d043982a1bd05a1184280c0d9166eb4d8d3fc"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -18,7 +18,6 @@
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm", "ba8836feea4b394bb718a161fc59a288fe0109b5006d6bdf97b6badfcf6f0f25"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/notifiex_test.exs
+++ b/test/notifiex_test.exs
@@ -3,19 +3,19 @@ defmodule NotifiexTest do
 
   test "must not work with unknown service" do
     # hope we support printers one day ;)
-    result = Notifiex.send(:printer, %{}, %{})
+    result = Notifiex.send(:printer, "{}", %{})
 
     assert result == {:error, {:unknown_service, :printer}}
   end
 
   test "must work with payload" do
-    result = Notifiex.send(:mock, %{hello: "world"}, %{})
+    result = Notifiex.send(:mock, "{\"hello\": \"world\"}", %{})
 
     assert result == {:ok, true}
   end
 
   test "must not work with empty payload" do
-    result = Notifiex.send(:mock, %{}, %{})
+    result = Notifiex.send(:mock, "", %{})
 
     assert result == {:error, {:mock_error, false}}
   end


### PR DESCRIPTION
Reason:
I had issue from my project because of the version of poison dependency.

Solution:
Reducing dependencies removing poison and change payload from map to string.